### PR TITLE
prefer newer --version=9.1 style

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -70,7 +70,7 @@ $ git add .
 $ git commit -am "init"
 $ heroku create -s cedar --buildpack=git://github.com/ryandotsmith/null-buildpack.git
 $ git push heroku master
-$ heroku addons:add heroku-postgresql:ika version=9.1
+$ heroku addons:add heroku-postgresql:ika --version=9.1
 $ heroku pg:psql
 - create table log_data (id bigserial, time timestamptz, data hstore);
 $ heroku scale wcld=1


### PR DESCRIPTION
Otherwise:

``` bash
$ heroku addons:add heroku-postgresql:ika version=9.1 -a wcld-receiver
       Warning: non-unix style params have been deprecated, use --version=9.1 instead
-----> Adding heroku-postgresql:ika to wcld-receiver... done, v4 ($800/mo)
       Attached as HEROKU_POSTGRESQL_YELLOW
       The database should be available in 3-5 minutes
               Use `heroku pg:wait` to track status
```
